### PR TITLE
fix: update default base URL and GitHub links to tensor-fusion.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
     <br />
     <a href="https://tensor-fusion.ai/guide/overview">View Demo</a>
     |
-    <a href="https://github.com/NexusGPU/tensor-fusion/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
+    <a href="https://github.com/NexusGPU/gpu-go/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
     |
-    <a href="https://github.com/NexusGPU/tensor-fusion/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
+    <a href="https://github.com/NexusGPU/gpu-go/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
 </p>
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
@@ -63,7 +63,7 @@ Create a **Studio** environment locally that is connected to the remote GPU.
 ggo auth login
 
 # Create a studio environment connected to a remote GPU
-ggo studio create my-project -s "https://go.gpu.tf/s/share-code"
+ggo studio create my-project -s "https://tensor-fusion.ai/s/share-code"
 
 # Connect via SSH (automatically configures your ~/.ssh/config)
 ggo studio ssh my-project
@@ -81,7 +81,7 @@ Prefer a GUI? The **GPU Go VS Code Extension** provides a beautiful interface to
 ## 💬 Community & Contact
 
 - Discord channel: [https://discord.gg/2bybv9yQNk](https://discord.gg/2bybv9yQNk)
-- Discuss anything about TensorFusion & GPUGo: [Github Discussions](https://github.com/NexusGPU/tensor-fusion/discussions)
+- Discuss anything about TensorFusion & GPUGo: [Github Discussions](https://github.com/NexusGPU/gpu-go/discussions)
 - Contact us with WeCom for Greater China region: [企业微信](https://work.weixin.qq.com/ca/cawcde42751d9f6a29)
 - Email us: [support@tensor-fusion.com](mailto:support@tensor-fusion.com)
 - Schedule [1:1 meeting with TensorFusion founders](https://tensor-fusion.ai/book-demo)

--- a/cmd/ggo/auth/auth.go
+++ b/cmd/ggo/auth/auth.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	tokenFileName   = "token.json"
-	dashboardURL    = "https://go.gpu.tf/settings/security#ide-extension"
+	dashboardURL    = "https://tensor-fusion.ai/settings/security#ide-extension"
 	defaultTokenTTL = 365 * 24 * time.Hour // 1 year
 )
 

--- a/cmd/ggo/launch/launch_linux.go
+++ b/cmd/ggo/launch/launch_linux.go
@@ -43,7 +43,7 @@ Examples:
   ggo launch -s abc123 python train.py
 
   # Launch Jupyter notebook
-  ggo launch -s https://go.gpu.tf/s/abc123 jupyter notebook
+  ggo launch -s https://tensor-fusion.ai/s/abc123 jupyter notebook
 
   # Launch with arguments
   ggo launch -s abc123 python -c "import torch; print(torch.cuda.is_available())"
@@ -68,7 +68,7 @@ Examples:
 }
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://go.gpu.tf/s/abc123", "go.gpu.tf/s/abc123"
+// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 

--- a/cmd/ggo/launch/launch_windows.go
+++ b/cmd/ggo/launch/launch_windows.go
@@ -65,7 +65,7 @@ Examples:
   ggo launch -s abc123 python train.py
 
   # Launch Jupyter notebook
-  ggo launch -s https://go.gpu.tf/s/abc123 jupyter notebook
+  ggo launch -s https://tensor-fusion.ai/s/abc123 jupyter notebook
 
   # Launch with arguments
   ggo launch -s abc123 python -c "import torch; print(torch.cuda.is_available())"
@@ -90,7 +90,7 @@ Examples:
 }
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://go.gpu.tf/s/abc123", "go.gpu.tf/s/abc123"
+// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 

--- a/cmd/ggo/share/share.go
+++ b/cmd/ggo/share/share.go
@@ -24,7 +24,7 @@ var (
 )
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://go.gpu.tf/s/abc123", "go.gpu.tf/s/abc123"
+// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 

--- a/cmd/ggo/use/use.go
+++ b/cmd/ggo/use/use.go
@@ -36,7 +36,7 @@ var (
 )
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://go.gpu.tf/s/abc123", "go.gpu.tf/s/abc123"
+// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 
@@ -78,7 +78,7 @@ Examples:
   ggo use abc123
 
   # Connect using full short link
-  ggo use https://go.gpu.tf/s/abc123
+  ggo use https://tensor-fusion.ai/s/abc123
 
   # Activate in current shell (recommended)
   eval "$(ggo use abc123 -y)"
@@ -235,7 +235,7 @@ Examples:
 
   # Clean up a specific connection (using code or link)
   ggo clean abc123
-  ggo clean https://go.gpu.tf/s/abc123
+  ggo clean https://tensor-fusion.ai/s/abc123
 
   # Clean up all GPU Go connections
   ggo clean --all`,

--- a/docs/deps-management.md
+++ b/docs/deps-management.md
@@ -133,7 +133,7 @@ ggo deps update -y
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `GPU_GO_ENDPOINT` | API base URL (default: https://go.gpu.tf) |
+| `GPU_GO_ENDPOINT` | API base URL (default: https://tensor-fusion.ai) |
 
 | Flag | Description |
 |------|-------------|

--- a/docs/studio-guide.md
+++ b/docs/studio-guide.md
@@ -18,7 +18,7 @@ GPU Go 提供两种使用远程 GPU 的方式：
 ggo use abc123
 
 # 使用完整链接
-ggo use https://go.gpu.tf/s/abc123
+ggo use https://tensor-fusion.ai/s/abc123
 
 # 直接激活，无需确认 (-y)
 ggo use abc123 -y
@@ -82,7 +82,7 @@ ggo clean --all
 ggo studio create my-studio -s abc123
 
 # 使用完整链接
-ggo studio create my-studio -s https://go.gpu.tf/s/abc123
+ggo studio create my-studio -s https://tensor-fusion.ai/s/abc123
 
 # 指定镜像
 ggo studio create my-studio -s abc123 --image tensorfusion/studio-torch:latest

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,20 +2,20 @@
   "name": "gpu-go",
   "displayName": "GPUGo",
   "description": "Use GPU Like NFS - Manage AI studio environments with remote GPU access. Create, connect, and manage GPU-powered development environments.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "publisher": "nexusgpu",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "images/icon.png",
   "homepage": "https://tensor-fusion.ai",
   "repository": {
     "type": "git",
-    "url": "https://github.com/NexusGPU/tensor-fusion"
+    "url": "https://github.com/NexusGPU/gpu-go"
   },
   "bugs": {
-    "url": "https://github.com/NexusGPU/tensor-fusion/issues",
+    "url": "https://github.com/NexusGPU/gpu-go/issues",
     "email": "support@tensor-fusion.com"
   },
-  "qna": "https://github.com/NexusGPU/tensor-fusion/discussions",
+  "qna": "https://github.com/NexusGPU/gpu-go/discussions",
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -288,7 +288,7 @@
       "properties": {
         "gpugo.serverUrl": {
           "type": "string",
-          "default": "https://go.gpu.tf",
+          "default": "https://tensor-fusion.ai",
           "description": "GPUGo API server URL"
         },
         "gpugo.dashboardUrl": {

--- a/vscode-extension/src/auth/authManager.ts
+++ b/vscode-extension/src/auth/authManager.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import { CLI } from '../cli/cli';
 import { Logger } from '../logger';
 
-const LOGIN_URL = 'https://go.gpu.tf/settings/security#ide-extension';
+const LOGIN_URL = 'https://tensor-fusion.ai/settings/security#ide-extension';
 
 export class AuthManager {
     private context: vscode.ExtensionContext;

--- a/vscode-extension/src/cli/cli.ts
+++ b/vscode-extension/src/cli/cli.ts
@@ -287,7 +287,7 @@ export class CLI {
         if (process.env.GPU_GO_ENDPOINT) {
             return process.env.GPU_GO_ENDPOINT;
         }
-        return vscode.workspace.getConfiguration('gpugo').get<string>('serverUrl', 'https://go.gpu.tf');
+        return vscode.workspace.getConfiguration('gpugo').get<string>('serverUrl', 'https://tensor-fusion.ai');
     }
 
     getDashboardUrl(): string {
@@ -375,7 +375,7 @@ export class CLI {
                             if (s === 'Settings') {
                                 vscode.commands.executeCommand('workbench.action.openSettings', 'gpugo.cliPath');
                             } else if (s === 'Install Guide') {
-                                vscode.env.openExternal(vscode.Uri.parse('https://go.gpu.tf/docs'));
+                                vscode.env.openExternal(vscode.Uri.parse('https://tensor-fusion.ai/docs'));
                             }
                         });
                     }

--- a/vscode-extension/src/views/createStudioPanel.ts
+++ b/vscode-extension/src/views/createStudioPanel.ts
@@ -320,7 +320,7 @@ export class CreateStudioPanel {
 
                 <vscode-form-group variant="vertical">
                     <vscode-label for="gpuUrl">Remote GPU Share Link</vscode-label>
-                    <vscode-textfield id="gpuUrl" name="gpuUrl" placeholder="e.g., abc123 or https://go.gpu.tf/s/abc123"></vscode-textfield>
+                    <vscode-textfield id="gpuUrl" name="gpuUrl" placeholder="e.g., abc123 or https://tensor-fusion.ai/s/abc123"></vscode-textfield>
                     <vscode-form-helper>Share link or code to a remote vGPU worker. If left empty, will use local GPU if applicable.</vscode-form-helper>
                 </vscode-form-group>
 


### PR DESCRIPTION
## Summary
- Update the default API base URL from `go.gpu.tf` to `tensor-fusion.ai` across the CLI, VS Code extension, and documentation
- Update GitHub repository links from `NexusGPU/tensor-fusion` to `NexusGPU/gpu-go` (bug reports, feature requests, discussions)
- Fix studio removal to gracefully handle containers that were deleted externally

## Changes
- **API client** (`internal/api/client.go`): default base URL → `https://tensor-fusion.ai`
- **CLI commands** (`auth`, `launch`, `share`, `use`): update dashboard URL and example URLs
- **VS Code extension**: update server URL default, login URL, docs URL, and `package.json` metadata
- **Documentation** (`README.md`, `docs/`): update all `go.gpu.tf` references and GitHub links
- **Studio manager** (`internal/studio/manager.go`): skip backend removal when container is already gone (status `Deleted`/`Unknown`)

## Test plan
- [ ] Verify CLI commands use the new `tensor-fusion.ai` URL by default
- [ ] Verify VS Code extension connects to `tensor-fusion.ai` with default settings
- [ ] Verify `ggo studio remove` succeeds for studios whose containers were externally deleted