### PR TITLE
fix: update share link examples to use gpu.tf short domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Create a **Studio** environment locally that is connected to the remote GPU.
 ggo auth login
 
 # Create a studio environment connected to a remote GPU
-ggo studio create my-project -s "https://tensor-fusion.ai/s/share-code"
+ggo studio create my-project -s "https://gpu.tf/s/share-code"
 
 # Connect via SSH (automatically configures your ~/.ssh/config)
 ggo studio ssh my-project

--- a/cmd/ggo/launch/launch_linux.go
+++ b/cmd/ggo/launch/launch_linux.go
@@ -43,7 +43,7 @@ Examples:
   ggo launch -s abc123 python train.py
 
   # Launch Jupyter notebook
-  ggo launch -s https://tensor-fusion.ai/s/abc123 jupyter notebook
+  ggo launch -s https://gpu.tf/s/abc123 jupyter notebook
 
   # Launch with arguments
   ggo launch -s abc123 python -c "import torch; print(torch.cuda.is_available())"
@@ -68,7 +68,7 @@ Examples:
 }
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
+// Supports formats: "abc123", "https://gpu.tf/s/abc123", "gpu.tf/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 

--- a/cmd/ggo/launch/launch_windows.go
+++ b/cmd/ggo/launch/launch_windows.go
@@ -65,7 +65,7 @@ Examples:
   ggo launch -s abc123 python train.py
 
   # Launch Jupyter notebook
-  ggo launch -s https://tensor-fusion.ai/s/abc123 jupyter notebook
+  ggo launch -s https://gpu.tf/s/abc123 jupyter notebook
 
   # Launch with arguments
   ggo launch -s abc123 python -c "import torch; print(torch.cuda.is_available())"
@@ -90,7 +90,7 @@ Examples:
 }
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
+// Supports formats: "abc123", "https://gpu.tf/s/abc123", "gpu.tf/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 

--- a/cmd/ggo/share/share.go
+++ b/cmd/ggo/share/share.go
@@ -24,7 +24,7 @@ var (
 )
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
+// Supports formats: "abc123", "https://gpu.tf/s/abc123", "gpu.tf/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 

--- a/cmd/ggo/use/use.go
+++ b/cmd/ggo/use/use.go
@@ -36,7 +36,7 @@ var (
 )
 
 // extractShortCode extracts the short code from a short link URL or returns the input as-is if it's already a code.
-// Supports formats: "abc123", "https://tensor-fusion.ai/s/abc123", "tensor-fusion.ai/s/abc123"
+// Supports formats: "abc123", "https://gpu.tf/s/abc123", "gpu.tf/s/abc123"
 func extractShortCode(input string) string {
 	input = strings.TrimSpace(input)
 
@@ -78,7 +78,7 @@ Examples:
   ggo use abc123
 
   # Connect using full short link
-  ggo use https://tensor-fusion.ai/s/abc123
+  ggo use https://gpu.tf/s/abc123
 
   # Activate in current shell (recommended)
   eval "$(ggo use abc123 -y)"
@@ -235,7 +235,7 @@ Examples:
 
   # Clean up a specific connection (using code or link)
   ggo clean abc123
-  ggo clean https://tensor-fusion.ai/s/abc123
+  ggo clean https://gpu.tf/s/abc123
 
   # Clean up all GPU Go connections
   ggo clean --all`,

--- a/docs/studio-guide.md
+++ b/docs/studio-guide.md
@@ -18,7 +18,7 @@ GPU Go 提供两种使用远程 GPU 的方式：
 ggo use abc123
 
 # 使用完整链接
-ggo use https://tensor-fusion.ai/s/abc123
+ggo use https://gpu.tf/s/abc123
 
 # 直接激活，无需确认 (-y)
 ggo use abc123 -y
@@ -82,7 +82,7 @@ ggo clean --all
 ggo studio create my-studio -s abc123
 
 # 使用完整链接
-ggo studio create my-studio -s https://tensor-fusion.ai/s/abc123
+ggo studio create my-studio -s https://gpu.tf/s/abc123
 
 # 指定镜像
 ggo studio create my-studio -s abc123 --image tensorfusion/studio-torch:latest

--- a/vscode-extension/src/views/createStudioPanel.ts
+++ b/vscode-extension/src/views/createStudioPanel.ts
@@ -317,7 +317,7 @@ export class CreateStudioPanel {
 
                 <vscode-form-group variant="vertical">
                     <vscode-label for="gpuUrl">Remote GPU Share Link</vscode-label>
-                    <vscode-textfield id="gpuUrl" name="gpuUrl" placeholder="e.g., abc123 or https://tensor-fusion.ai/s/abc123"></vscode-textfield>
+                    <vscode-textfield id="gpuUrl" name="gpuUrl" placeholder="e.g., abc123 or https://gpu.tf/s/abc123"></vscode-textfield>
                     <vscode-form-helper>Share link or code to a remote vGPU worker. If left empty, will use local GPU if applicable.</vscode-form-helper>
                 </vscode-form-group>
 


### PR DESCRIPTION
## Summary
- Updated all share link examples, comments, and placeholder text from `https://tensor-fusion.ai/s/<code>` to `https://gpu.tf/s/<code>` to match the actual short link format