### PR TITLE
docs: update View Demo link to new docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <br />
     <a href="https://tensor-fusion.ai/guide/overview"><strong>Explore the docs »</strong></a>
     <br />
-    <a href="https://tensor-fusion.ai/guide/overview">View Demo</a>
+    <a href="https://tensor-fusion.ai/docs/gpu-go/overview#gpu-go-overview">View Demo</a>
     |
     <a href="https://github.com/NexusGPU/gpu-go/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
     |


### PR DESCRIPTION
## Summary
- Update the "View Demo" link in README.md to point to the new docs URL (`tensor-fusion.ai/docs/gpu-go/overview#gpu-go-overview`) instead of the old overview page.

## Test plan
- [x] Verify the new URL is correct and accessible